### PR TITLE
Remove deprecated amount update stream

### DIFF
--- a/lib/generated/rust/api/stream.dart
+++ b/lib/generated/rust/api/stream.dart
@@ -18,6 +18,3 @@ Stream<ScanProgress> createScanProgressStream() =>
 
 Stream<ScanResult> createScanResultStream() =>
     RustLib.instance.api.crateApiStreamCreateScanResultStream();
-
-Stream<BigInt> createAmountStream() =>
-    RustLib.instance.api.crateApiStreamCreateAmountStream();

--- a/lib/generated/rust/frb_generated.dart
+++ b/lib/generated/rust/frb_generated.dart
@@ -74,7 +74,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.3.0';
 
   @override
-  int get rustContentHash => -1290951533;
+  int get rustContentHash => 1362422988;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -109,8 +109,6 @@ abstract class RustLibApi extends BaseApi {
       required bool finalize});
 
   Future<void> crateApiSimpleInitApp();
-
-  Stream<BigInt> crateApiStreamCreateAmountStream();
 
   Stream<LogEntry> crateApiStreamCreateLogStream(
       {required LogLevel level, required bool logDependencies});
@@ -382,32 +380,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Stream<BigInt> crateApiStreamCreateAmountStream() {
-    final s = RustStreamSink<BigInt>();
-    handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_StreamSink_u_64_Sse(s, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_unit,
-        decodeErrorData: null,
-      ),
-      constMeta: kCrateApiStreamCreateAmountStreamConstMeta,
-      argValues: [s],
-      apiImpl: this,
-    ));
-    return s.stream;
-  }
-
-  TaskConstMeta get kCrateApiStreamCreateAmountStreamConstMeta =>
-      const TaskConstMeta(
-        debugName: "create_amount_stream",
-        argNames: ["s"],
-      );
-
-  @override
   Stream<LogEntry> crateApiStreamCreateLogStream(
       {required LogLevel level, required bool logDependencies}) {
     final s = RustStreamSink<LogEntry>();
@@ -417,7 +389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_StreamSink_log_entry_Sse(s, serializer);
         sse_encode_log_level(level, serializer);
         sse_encode_bool(logDependencies, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -443,7 +415,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_scan_progress_Sse(s, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -469,7 +441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_scan_result_Sse(s, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -494,7 +466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_amount(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -518,7 +490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_recorded_transaction_incoming(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -544,7 +516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_recorded_transaction_outgoing(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -576,7 +548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(txid, serializer);
         sse_encode_box_autoadd_amount(amount, serializer);
         sse_encode_u_32(height, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -607,7 +579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(txid, serializer);
         sse_encode_list_String(spentOutpoints, serializer);
         sse_encode_list_recipient(recipients, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -633,7 +605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encodedWallet, serializer);
         sse_encode_u_32(birthday, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -657,7 +629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encodedWallet, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_wallet_status,
@@ -686,7 +658,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(encodedWallet, serializer);
         sse_encode_String(spentBy, serializer);
         sse_encode_list_String(spent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -710,7 +682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encodedWallet, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -739,7 +711,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(dustLimit, serializer);
         sse_encode_String(encodedWallet, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 22, port: port_);
+            funcId: 21, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -774,7 +746,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(birthday, serializer);
         sse_encode_String(network, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 23, port: port_);
+            funcId: 22, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -804,7 +776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encodedWallet, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -850,12 +822,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   RustStreamSink<ScanResult> dco_decode_StreamSink_scan_result_Sse(
       dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    throw UnimplementedError();
-  }
-
-  @protected
-  RustStreamSink<BigInt> dco_decode_StreamSink_u_64_Sse(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
@@ -1189,13 +1155,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   RustStreamSink<ScanResult> sse_decode_StreamSink_scan_result_Sse(
-      SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    throw UnimplementedError('Unreachable ()');
-  }
-
-  @protected
-  RustStreamSink<BigInt> sse_decode_StreamSink_u_64_Sse(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     throw UnimplementedError('Unreachable ()');
@@ -1572,19 +1531,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         self.setupAndSerialize(
             codec: SseCodec(
           decodeSuccessData: sse_decode_scan_result,
-          decodeErrorData: sse_decode_AnyhowException,
-        )),
-        serializer);
-  }
-
-  @protected
-  void sse_encode_StreamSink_u_64_Sse(
-      RustStreamSink<BigInt> self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(
-        self.setupAndSerialize(
-            codec: SseCodec(
-          decodeSuccessData: sse_decode_u_64,
           decodeErrorData: sse_decode_AnyhowException,
         )),
         serializer);

--- a/lib/generated/rust/frb_generated.io.dart
+++ b/lib/generated/rust/frb_generated.io.dart
@@ -41,9 +41,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RustStreamSink<ScanResult> dco_decode_StreamSink_scan_result_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<BigInt> dco_decode_StreamSink_u_64_Sse(dynamic raw);
-
-  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -161,10 +158,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   RustStreamSink<ScanResult> sse_decode_StreamSink_scan_result_Sse(
-      SseDeserializer deserializer);
-
-  @protected
-  RustStreamSink<BigInt> sse_decode_StreamSink_u_64_Sse(
       SseDeserializer deserializer);
 
   @protected
@@ -293,10 +286,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_StreamSink_scan_result_Sse(
       RustStreamSink<ScanResult> self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_StreamSink_u_64_Sse(
-      RustStreamSink<BigInt> self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);

--- a/lib/generated/rust/frb_generated.web.dart
+++ b/lib/generated/rust/frb_generated.web.dart
@@ -43,9 +43,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RustStreamSink<ScanResult> dco_decode_StreamSink_scan_result_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<BigInt> dco_decode_StreamSink_u_64_Sse(dynamic raw);
-
-  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -163,10 +160,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   RustStreamSink<ScanResult> sse_decode_StreamSink_scan_result_Sse(
-      SseDeserializer deserializer);
-
-  @protected
-  RustStreamSink<BigInt> sse_decode_StreamSink_u_64_Sse(
       SseDeserializer deserializer);
 
   @protected
@@ -295,10 +288,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_StreamSink_scan_result_Sse(
       RustStreamSink<ScanResult> self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_StreamSink_u_64_Sse(
-      RustStreamSink<BigInt> self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -75,10 +75,6 @@ class WalletState extends ChangeNotifier {
       await updateWalletStatus();
     }));
 
-    amountStreamSubscription = createAmountStream().listen((event) {
-      amount = event;
-      notifyListeners();
-    });
   }
 
   @override

--- a/rust/src/api/stream.rs
+++ b/rust/src/api/stream.rs
@@ -19,8 +19,3 @@ pub fn create_scan_progress_stream(s: StreamSink<ScanProgress>) {
 pub fn create_scan_result_stream(s: StreamSink<ScanResult>) {
     stream::create_scan_result_stream(s);
 }
-
-#[flutter_rust_bridge::frb(sync)]
-pub fn create_amount_stream(s: StreamSink<u64>) {
-    stream::create_amount_stream(s);
-}

--- a/rust/src/blindbit/logic.rs
+++ b/rust/src/blindbit/logic.rs
@@ -20,7 +20,7 @@ use sp_client::{
     spclient::{OutputList, SpWallet},
 };
 
-use crate::stream::{send_amount_update, send_scan_progress, send_scan_result, ScanProgress};
+use crate::stream::{send_scan_progress, send_scan_result, ScanProgress};
 use crate::{
     blindbit::client::{BlindbitClient, UtxoResponse},
     stream::ScanResult,
@@ -122,7 +122,6 @@ pub async fn scan_blocks(
             send_update = true;
             let height = Height::from_consensus(blkheight)?;
             sp_wallet.record_block_outputs(height, found_outputs);
-            send_amount_update(sp_wallet.get_outputs().get_balance().to_sat());
         }
 
         if !found_inputs.is_empty() {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.3.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1290951533;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1362422988;
 
 // Section: executor
 
@@ -328,40 +328,6 @@ fn wire__crate__api__simple__init_app_impl(
                     Ok(output_ok)
                 })())
             }
-        },
-    )
-}
-fn wire__crate__api__stream__create_amount_stream_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "create_amount_stream",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_s = <StreamSink<u64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                &mut deserializer,
-            );
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok = Result::<_, ()>::Ok({
-                    crate::api::stream::create_amount_stream(api_s);
-                })?;
-                Ok(output_ok)
-            })())
         },
     )
 }
@@ -959,14 +925,6 @@ impl SseDecode
     }
 }
 
-impl SseDecode for StreamSink<u64, flutter_rust_bridge::for_generated::SseCodec> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <String>::sse_decode(deserializer);
-        return StreamSink::deserialize(inner);
-    }
-}
-
 impl SseDecode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -1328,8 +1286,8 @@ fn pde_ffi_dispatcher_primary_impl(
         1 => wire__crate__api__chain__get_chain_height_impl(port, ptr, rust_vec_len, data_len),
         3 => wire__crate__api__psbt__broadcast_tx_impl(port, ptr, rust_vec_len, data_len),
         8 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet__scan_to_tip_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__wallet__setup_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__wallet__scan_to_tip_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__wallet__setup_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1347,34 +1305,33 @@ fn pde_ffi_dispatcher_sync_impl(
         5 => wire__crate__api__psbt__extract_tx_from_psbt_impl(ptr, rust_vec_len, data_len),
         6 => wire__crate__api__psbt__fill_sp_outputs_impl(ptr, rust_vec_len, data_len),
         7 => wire__crate__api__psbt__sign_psbt_impl(ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__stream__create_amount_stream_impl(ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__stream__create_log_stream_impl(ptr, rust_vec_len, data_len),
-        11 => {
+        9 => wire__crate__api__stream__create_log_stream_impl(ptr, rust_vec_len, data_len),
+        10 => {
             wire__crate__api__stream__create_scan_progress_stream_impl(ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__stream__create_scan_result_stream_impl(ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__structs__amount_to_int_impl(ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__structs__recorded_transaction_incoming_to_string_impl(
+        11 => wire__crate__api__stream__create_scan_result_stream_impl(ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__structs__amount_to_int_impl(ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__structs__recorded_transaction_incoming_to_string_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__structs__recorded_transaction_outgoing_to_string_impl(
+        14 => wire__crate__api__structs__recorded_transaction_outgoing_to_string_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        16 => {
+        15 => {
             wire__crate__api__wallet__add_incoming_tx_to_history_impl(ptr, rust_vec_len, data_len)
         }
-        17 => {
+        16 => {
             wire__crate__api__wallet__add_outgoing_tx_to_history_impl(ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__wallet__change_birthday_impl(ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__wallet__get_wallet_info_impl(ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__wallet__mark_outpoints_spent_impl(ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__wallet__reset_wallet_impl(ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__wallet__show_mnemonic_impl(ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__wallet__change_birthday_impl(ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__wallet__get_wallet_info_impl(ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__wallet__mark_outpoints_spent_impl(ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__wallet__reset_wallet_impl(ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__wallet__show_mnemonic_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1675,13 +1632,6 @@ impl SseEncode
 impl SseEncode
     for StreamSink<crate::stream::ScanResult, flutter_rust_bridge::for_generated::SseCodec>
 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        unimplemented!("")
-    }
-}
-
-impl SseEncode for StreamSink<u64, flutter_rust_bridge::for_generated::SseCodec> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         unimplemented!("")

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -4,7 +4,6 @@ use crate::frb_generated::StreamSink;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref AMOUNT_STREAM_SINK: Mutex<Option<StreamSink<u64>>> = Mutex::new(None);
     static ref SCAN_PROGRESS_STREAM_SINK: Mutex<Option<StreamSink<ScanProgress>>> =
         Mutex::new(None);
     static ref SCAN_RESULT_STREAM_SINK: Mutex<Option<StreamSink<ScanResult>>> = Mutex::new(None);
@@ -20,11 +19,6 @@ pub struct ScanResult {
     pub updated_wallet: String,
 }
 
-pub fn create_amount_stream(s: StreamSink<u64>) {
-    let mut stream_sink = AMOUNT_STREAM_SINK.lock().unwrap();
-    *stream_sink = Some(s);
-}
-
 pub fn create_scan_progress_stream(s: StreamSink<ScanProgress>) {
     let mut stream_sink = SCAN_PROGRESS_STREAM_SINK.lock().unwrap();
     *stream_sink = Some(s);
@@ -33,13 +27,6 @@ pub fn create_scan_progress_stream(s: StreamSink<ScanProgress>) {
 pub fn create_scan_result_stream(s: StreamSink<ScanResult>) {
     let mut stream_sink = SCAN_RESULT_STREAM_SINK.lock().unwrap();
     *stream_sink = Some(s);
-}
-
-pub(crate) fn send_amount_update(amount: u64) {
-    let stream_sink = AMOUNT_STREAM_SINK.lock().unwrap();
-    if let Some(stream_sink) = stream_sink.as_ref() {
-        stream_sink.add(amount).unwrap();
-    }
 }
 
 pub(crate) fn send_scan_progress(scan_progress: ScanProgress) {


### PR DESCRIPTION
This is superceded by the 'intermediate scan result' stream, which also sends other wallet information.