### PR TITLE
Refactor wallet loading into main instead of home

### DIFF
--- a/lib/screens/create/create_wallet.dart
+++ b/lib/screens/create/create_wallet.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/generated/rust/api/wallet.dart';
+import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/services/settings_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/theme_notifier.dart';
@@ -51,7 +52,10 @@ class CreateWalletScreenState extends State<CreateWalletScreen> {
 
     try {
       await walletState.updateWalletStatus();
-      walletState.walletLoaded = true;
+      if (mounted) {
+        Navigator.pushReplacement(context,
+            MaterialPageRoute(builder: (context) => const HomeScreen()));
+      }
       return;
     } catch (e) {
       Logger().i("Creating a new wallet");
@@ -78,7 +82,11 @@ class CreateWalletScreenState extends State<CreateWalletScreen> {
       );
       await walletState.saveWalletToSecureStorage(wallet);
       await walletState.updateWalletStatus();
-      walletState.walletLoaded = true;
+
+      if (mounted) {
+        Navigator.pushReplacement(context,
+            MaterialPageRoute(builder: (context) => const HomeScreen()));
+      }
     } catch (e) {
       rethrow;
     }

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -1,10 +1,5 @@
-import 'dart:async';
-
 import 'package:bitcoin_ui/bitcoin_ui.dart';
-import 'package:danawallet/screens/create/create_wallet.dart';
-import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/home_state.dart';
-import 'package:danawallet/states/theme_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/screens/home/history/tx_history.dart';
 import 'package:danawallet/screens/home/wallet/wallet.dart';
@@ -12,62 +7,19 @@ import 'package:danawallet/screens/home/settings/settings.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class HomeScreen extends StatefulWidget {
+class HomeScreen extends StatelessWidget {
+  static const List<Widget> _widgetOptions = [
+    WalletScreen(),
+    TxHistoryscreen(),
+    SettingsScreen(),
+  ];
+
   const HomeScreen({super.key});
 
   @override
-  HomeScreenState createState() => HomeScreenState();
-}
-
-class HomeScreenState extends State<HomeScreen> {
-  bool isLoading = true;
-  final List<Widget> _widgetOptions = [
-    const WalletScreen(),
-    const TxHistoryscreen(),
-    const SettingsScreen(),
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-    _checkWallet();
-  }
-
-  Future<void> _checkWallet() async {
-    final walletState = Provider.of<WalletState>(context, listen: false);
-    final chainState = Provider.of<ChainState>(context, listen: false);
-    final themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
-    try {
-      await walletState.updateWalletStatus();
-      await chainState.initialize();
-      themeNotifier.setTheme(walletState.network);
-
-      walletState.walletLoaded = true;
-    } catch (e) {
-      walletState.walletLoaded = false;
-    }
-    setState(() {
-      isLoading = false;
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final walletState = Provider.of<WalletState>(context, listen: true);
+    final walletState = Provider.of<WalletState>(context, listen: false);
     final homeState = Provider.of<HomeState>(context, listen: true);
-
-    if (isLoading) {
-      return const MaterialApp(
-        home: Scaffold(
-          body: Center(child: CircularProgressIndicator()),
-        ),
-      );
-    }
-
-    if (!walletState.walletLoaded) {
-      // go to create wallet screen
-      return const CreateWalletScreen();
-    }
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/home/settings/settings.dart
+++ b/lib/screens/home/settings/settings.dart
@@ -1,6 +1,7 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/generated/rust/api/wallet.dart';
+import 'package:danawallet/screens/create/create_wallet.dart';
 import 'package:danawallet/services/settings_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/home_state.dart';
@@ -18,7 +19,6 @@ class SettingsScreen extends StatelessWidget {
     ChainState chainState,
     SpendState spendSelectionState,
     ThemeNotifier themeNotifier,
-    HomeState homeIndexProvider,
   ) async {
     try {
       await walletState.rmWalletFromSecureStorage();
@@ -28,7 +28,6 @@ class SettingsScreen extends StatelessWidget {
       spendSelectionState.reset();
       chainState.reset();
       themeNotifier.setTheme(null);
-      homeIndexProvider.showMainScreen();
     } catch (e) {
       rethrow;
     }
@@ -137,10 +136,18 @@ class SettingsScreen extends StatelessWidget {
             },
           ),
           BitcoinButtonOutlined(
-            title: 'Wipe wallet',
-            onPressed: () => _removeWallet(walletState, chainState, spendState,
-                themeNotifier, homeProvider),
-          ),
+              title: 'Wipe wallet',
+              onPressed: () async {
+                await _removeWallet(
+                    walletState, chainState, spendState, themeNotifier);
+                homeProvider.showMainScreen();
+                if (context.mounted) {
+                  Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const CreateWalletScreen()));
+                }
+              }),
         ],
       ),
     );

--- a/lib/screens/home/wallet/wallet.dart
+++ b/lib/screens/home/wallet/wallet.dart
@@ -179,12 +179,6 @@ class WalletScreenState extends State<WalletScreen> {
             },
             child: const Text('Scan'));
 
-    if (!walletState.walletLoaded) {
-      return const Center(
-        child: CircularProgressIndicator(),
-      );
-    }
-
     return Column(
       children: [
         Expanded(


### PR DESCRIPTION
This does some general refactoring but also closes #49.

If a wallet is loaded that has an unknown format, the screen stays black. Although that is not pretty, it alleviates the problem where users accidentally delete their wallet.