### PR TITLE
Set keyboard type as email for recipient field

### DIFF
--- a/lib/screens/home/wallet/spend/add_recipient.dart
+++ b/lib/screens/home/wallet/spend/add_recipient.dart
@@ -30,6 +30,7 @@ class AddRecipientWidgetState extends State<AddRecipientWidget> {
         children: <Widget>[
           TextFormField(
             controller: addressController,
+            keyboardType: TextInputType.emailAddress,
             decoration: InputDecoration(
               labelText: 'Recipient',
               hintText: 'satoshi@bitcoin.org, sp1q..., bc1q...',


### PR DESCRIPTION
Recipient will be either a bitcoin address (pasted from clipboard), or a BIP353 style address. In the latter case, an email keyboard would be more useful.