### PR TITLE
Move SpWallet from sp client library to dana

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "sp_client"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/sp-client?branch=master#2ec5d85486f2301fff6b32777f0e70d2f95821c0"
+source = "git+https://github.com/cygnet3/sp-client?branch=master#1e9fc52fe3f7971c2f5935eaea8c386f7c5f4e05"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/rust/src/api/psbt.rs
+++ b/rust/src/api/psbt.rs
@@ -5,7 +5,9 @@ use log::info;
 use pushtx::Network;
 use sp_client::bitcoin;
 use sp_client::bitcoin::{consensus::encode::serialize_hex, OutPoint, Psbt};
-use sp_client::spclient::{SpClient, SpWallet};
+use sp_client::spclient::SpClient;
+
+use crate::wallet::spwallet::SpWallet;
 
 use super::structs::{Amount, OwnedOutput, Recipient};
 use anyhow::{anyhow, Error, Result};

--- a/rust/src/api/structs.rs
+++ b/rust/src/api/structs.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, str::FromStr};
 use serde::{Deserialize, Serialize};
 use sp_client::bitcoin::{self, absolute::Height, OutPoint, Txid};
 
+use crate::wallet;
+
 type SpendingTxId = String;
 type MinedInBlock = String;
 
@@ -154,21 +156,21 @@ pub struct RecordedTransactionOutgoing {
     pub change: Amount,
 }
 
-impl From<sp_client::spclient::RecordedTransaction> for RecordedTransaction {
-    fn from(value: sp_client::spclient::RecordedTransaction) -> Self {
+impl From<wallet::recorded::RecordedTransaction> for RecordedTransaction {
+    fn from(value: wallet::recorded::RecordedTransaction) -> Self {
         match value {
-            sp_client::spclient::RecordedTransaction::Incoming(incoming) => {
+            wallet::recorded::RecordedTransaction::Incoming(incoming) => {
                 Self::Incoming(incoming.into())
             }
 
-            sp_client::spclient::RecordedTransaction::Outgoing(outgoing) => {
+            wallet::recorded::RecordedTransaction::Outgoing(outgoing) => {
                 Self::Outgoing(outgoing.into())
             }
         }
     }
 }
 
-impl From<RecordedTransaction> for sp_client::spclient::RecordedTransaction {
+impl From<RecordedTransaction> for wallet::recorded::RecordedTransaction {
     fn from(value: RecordedTransaction) -> Self {
         match value {
             RecordedTransaction::Incoming(incoming) => Self::Incoming(incoming.into()),
@@ -177,8 +179,8 @@ impl From<RecordedTransaction> for sp_client::spclient::RecordedTransaction {
     }
 }
 
-impl From<sp_client::spclient::RecordedTransactionIncoming> for RecordedTransactionIncoming {
-    fn from(value: sp_client::spclient::RecordedTransactionIncoming) -> Self {
+impl From<wallet::recorded::RecordedTransactionIncoming> for RecordedTransactionIncoming {
+    fn from(value: wallet::recorded::RecordedTransactionIncoming) -> Self {
         let confirmed_at = value.confirmed_at.map(|height| height.to_consensus_u32());
 
         Self {
@@ -189,7 +191,7 @@ impl From<sp_client::spclient::RecordedTransactionIncoming> for RecordedTransact
     }
 }
 
-impl From<RecordedTransactionIncoming> for sp_client::spclient::RecordedTransactionIncoming {
+impl From<RecordedTransactionIncoming> for wallet::recorded::RecordedTransactionIncoming {
     fn from(value: RecordedTransactionIncoming) -> Self {
         let confirmed_at = value
             .confirmed_at
@@ -203,8 +205,8 @@ impl From<RecordedTransactionIncoming> for sp_client::spclient::RecordedTransact
     }
 }
 
-impl From<sp_client::spclient::RecordedTransactionOutgoing> for RecordedTransactionOutgoing {
-    fn from(value: sp_client::spclient::RecordedTransactionOutgoing) -> Self {
+impl From<wallet::recorded::RecordedTransactionOutgoing> for RecordedTransactionOutgoing {
+    fn from(value: wallet::recorded::RecordedTransactionOutgoing) -> Self {
         let confirmed_at = value.confirmed_at.map(|height| height.to_consensus_u32());
 
         Self {
@@ -221,7 +223,7 @@ impl From<sp_client::spclient::RecordedTransactionOutgoing> for RecordedTransact
     }
 }
 
-impl From<RecordedTransactionOutgoing> for sp_client::spclient::RecordedTransactionOutgoing {
+impl From<RecordedTransactionOutgoing> for wallet::recorded::RecordedTransactionOutgoing {
     fn from(value: RecordedTransactionOutgoing) -> Self {
         let confirmed_at = value
             .confirmed_at

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,15 +1,19 @@
 use std::str::FromStr;
 
+use crate::{
+    blindbit,
+    wallet::spwallet::{derive_keys_from_seed, SpWallet},
+};
 use anyhow::{Error, Result};
 use reqwest::Url;
-use sp_client::bitcoin::{
-    absolute::Height,
-    secp256k1::{PublicKey, SecretKey},
-    Network, OutPoint, Txid,
+use sp_client::{
+    bitcoin::{
+        absolute::Height,
+        secp256k1::{PublicKey, SecretKey},
+        Network, OutPoint, Txid,
+    },
+    spclient::{SpClient, SpendKey},
 };
-use sp_client::spclient::{derive_keys_from_seed, SpClient, SpWallet, SpendKey};
-
-use crate::blindbit;
 
 use super::structs::{Amount, Recipient, WalletStatus};
 

--- a/rust/src/blindbit/logic.rs
+++ b/rust/src/blindbit/logic.rs
@@ -14,16 +14,17 @@ use sp_client::bitcoin::{
     secp256k1::{PublicKey, Scalar},
     Amount, BlockHash, OutPoint, Txid, XOnlyPublicKey,
 };
+use sp_client::silentpayments::receiving::Label;
 use sp_client::spclient::{OutputSpendStatus, OwnedOutput, SpClient};
-use sp_client::{
-    silentpayments::receiving::Label,
-    spclient::{OutputList, SpWallet},
-};
 
-use crate::stream::{send_scan_progress, send_scan_result, ScanProgress};
 use crate::{
     blindbit::client::{BlindbitClient, UtxoResponse},
     stream::ScanResult,
+    wallet::outputslist::OutputList,
+};
+use crate::{
+    stream::{send_scan_progress, send_scan_result, ScanProgress},
+    wallet::spwallet::SpWallet,
 };
 
 use super::client::FilterResponse;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,3 +3,4 @@ mod blindbit;
 mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 mod logger;
 mod stream;
+mod wallet;

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -1,0 +1,3 @@
+pub mod outputslist;
+pub mod recorded;
+pub mod spwallet;

--- a/rust/src/wallet/outputslist.rs
+++ b/rust/src/wallet/outputslist.rs
@@ -1,0 +1,172 @@
+use std::{collections::HashMap, io::Write};
+
+use anyhow::{Error, Result};
+use serde::{Deserialize, Serialize};
+use sp_client::{
+    bitcoin::{hashes::Hash, secp256k1::PublicKey, Amount, BlockHash, OutPoint, Txid},
+    silentpayments::{self, utils::SilentPaymentAddress},
+    spclient::{OutputSpendStatus, OwnedOutput, SpClient},
+};
+
+type WalletFingerprint = [u8; 8];
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct OutputList {
+    pub wallet_fingerprint: WalletFingerprint,
+    birthday: u32,
+    last_scan: u32,
+    outputs: HashMap<OutPoint, OwnedOutput>,
+}
+
+impl OutputList {
+    pub fn new(scan_pk: PublicKey, spend_pk: PublicKey, birthday: u32) -> Self {
+        // take a fingerprint of the wallet by hashing its keys
+        let mut engine = silentpayments::bitcoin_hashes::sha256::HashEngine::default();
+        engine
+            .write_all(&scan_pk.serialize())
+            .expect("Failed to write scan_pk to engine");
+        engine
+            .write_all(&spend_pk.serialize())
+            .expect("Failed to write spend_pk to engine");
+        let hash = silentpayments::bitcoin_hashes::sha256::Hash::from_engine(engine);
+        let mut wallet_fingerprint = [0u8; 8];
+        wallet_fingerprint.copy_from_slice(&hash.to_byte_array()[..8]);
+        let outputs = HashMap::new();
+        Self {
+            wallet_fingerprint,
+            outputs,
+            birthday,
+            last_scan: birthday,
+        }
+    }
+
+    pub fn check_fingerprint(&self, client: &SpClient) -> bool {
+        let sp_address: SilentPaymentAddress = client.get_receiving_address().try_into().unwrap();
+        let new = Self::new(sp_address.get_scan_key(), sp_address.get_spend_key(), 0);
+        new.wallet_fingerprint == self.wallet_fingerprint
+    }
+
+    pub fn get_birthday(&self) -> u32 {
+        self.birthday
+    }
+
+    pub fn get_last_scan(&self) -> u32 {
+        self.last_scan
+    }
+
+    pub fn set_birthday(&mut self, new_birthday: u32) {
+        self.birthday = new_birthday;
+    }
+
+    pub fn update_last_scan(&mut self, scan_height: u32) {
+        self.last_scan = scan_height;
+    }
+
+    pub(crate) fn reset_to_height(&mut self, height: u32) {
+        let new_outputs = self
+            .to_outpoints_list()
+            .into_iter()
+            .filter(|(_, o)| o.blockheight < height)
+            .collect::<HashMap<OutPoint, OwnedOutput>>();
+        self.outputs = new_outputs;
+    }
+
+    pub fn to_outpoints_list(&self) -> HashMap<OutPoint, OwnedOutput> {
+        self.outputs.clone()
+    }
+
+    pub fn extend_from(&mut self, new: HashMap<OutPoint, OwnedOutput>) {
+        self.outputs.extend(new);
+    }
+
+    pub fn get_balance(&self) -> Amount {
+        self.outputs
+            .iter()
+            .filter(|(_, o)| o.spend_status == OutputSpendStatus::Unspent)
+            .fold(Amount::from_sat(0), |acc, x| acc + x.1.amount)
+    }
+
+    #[allow(dead_code)]
+    pub fn to_spendable_list(&self) -> HashMap<OutPoint, OwnedOutput> {
+        self.to_outpoints_list()
+            .into_iter()
+            .filter(|(_, o)| o.spend_status == OutputSpendStatus::Unspent)
+            .collect()
+    }
+
+    pub fn get_outpoint(&self, outpoint: OutPoint) -> Result<(OutPoint, OwnedOutput)> {
+        let output = self
+            .to_outpoints_list()
+            .get_key_value(&outpoint)
+            .ok_or_else(|| Error::msg("Outpoint not in list"))?
+            .1
+            .to_owned();
+
+        Ok((outpoint, output))
+    }
+
+    pub fn mark_spent(
+        &mut self,
+        outpoint: OutPoint,
+        spending_tx: Txid,
+        force_update: bool,
+    ) -> Result<()> {
+        let (outpoint, mut output) = self.get_outpoint(outpoint)?;
+
+        match output.spend_status {
+            OutputSpendStatus::Unspent => {
+                let tx_hex = spending_tx.to_string();
+                output.spend_status = OutputSpendStatus::Spent(tx_hex);
+                self.outputs.insert(outpoint, output);
+                Ok(())
+            }
+            OutputSpendStatus::Spent(tx_hex) => {
+                // We may want to fail if that's the case, or force update if we know what we're doing
+                if force_update {
+                    let tx_hex = spending_tx.to_string();
+                    output.spend_status = OutputSpendStatus::Spent(tx_hex);
+                    self.outputs.insert(outpoint, output);
+                    Ok(())
+                } else {
+                    Err(Error::msg(format!(
+                        "Output already spent by transaction {}",
+                        tx_hex
+                    )))
+                }
+            }
+            OutputSpendStatus::Mined(block) => Err(Error::msg(format!(
+                "Output already mined in block {}",
+                block
+            ))),
+        }
+    }
+
+    /// Mark the output as being spent in block `mined_in_block`
+    /// We don't really need to check the previous status, if it's in a block there's nothing we can do
+    pub fn mark_mined(&mut self, outpoint: OutPoint, mined_in_block: BlockHash) -> Result<()> {
+        let (outpoint, mut output) = self.get_outpoint(outpoint)?;
+
+        let block_hex = mined_in_block.to_string();
+        output.spend_status = OutputSpendStatus::Mined(block_hex);
+        self.outputs.insert(outpoint, output);
+        Ok(())
+    }
+
+    /// Revert the outpoint status to Unspent, regardless of the current status
+    /// This could be useful on some rare occurrences, like a transaction falling out of mempool after a while
+    /// Watch out we also reverse the mined state, use with caution
+    #[allow(dead_code)]
+    pub fn revert_spent_status(&mut self, outpoint: OutPoint) -> Result<()> {
+        let (outpoint, mut output) = self.get_outpoint(outpoint)?;
+
+        if output.spend_status != OutputSpendStatus::Unspent {
+            output.spend_status = OutputSpendStatus::Unspent;
+            self.outputs.insert(outpoint, output);
+        }
+        Ok(())
+    }
+
+    pub fn get_mut(&mut self, outpoint: &OutPoint) -> Option<&mut OwnedOutput> {
+        self.outputs.get_mut(outpoint)
+    }
+}

--- a/rust/src/wallet/recorded.rs
+++ b/rust/src/wallet/recorded.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+use sp_client::{
+    bitcoin::{absolute::Height, Amount, OutPoint, Txid},
+    spclient::Recipient,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum RecordedTransaction {
+    Incoming(RecordedTransactionIncoming),
+    Outgoing(RecordedTransactionOutgoing),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct RecordedTransactionIncoming {
+    pub txid: Txid,
+    pub amount: Amount,
+    pub confirmed_at: Option<Height>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct RecordedTransactionOutgoing {
+    pub txid: Txid,
+    pub spent_outpoints: Vec<OutPoint>,
+    pub recipients: Vec<Recipient>,
+    pub confirmed_at: Option<Height>,
+    pub change: Amount,
+}

--- a/rust/src/wallet/spwallet.rs
+++ b/rust/src/wallet/spwallet.rs
@@ -1,0 +1,312 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use sp_client::bitcoin::absolute::Height;
+use sp_client::bitcoin::bip32::{DerivationPath, Xpriv};
+use sp_client::bitcoin::hex::DisplayHex;
+use sp_client::bitcoin::secp256k1::SecretKey;
+use sp_client::bitcoin::{self, Amount, BlockHash, Network, Txid, XOnlyPublicKey};
+use sp_client::bitcoin::{key::Secp256k1, secp256k1::PublicKey, OutPoint, Transaction};
+
+use anyhow::{Error, Result};
+
+use sp_client::silentpayments::utils as sp_utils;
+use sp_client::spclient::{OutputSpendStatus, OwnedOutput, Recipient, SpClient};
+
+use super::outputslist::OutputList;
+use super::recorded::{
+    RecordedTransaction, RecordedTransactionIncoming, RecordedTransactionOutgoing,
+};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SpWallet {
+    client: SpClient,
+    outputs: OutputList,
+    tx_history: Vec<RecordedTransaction>,
+}
+
+impl SpWallet {
+    pub fn new(
+        client: SpClient,
+        outputs: Option<OutputList>,
+        tx_history: Vec<RecordedTransaction>,
+    ) -> Result<Self> {
+        if let Some(existing_outputs) = outputs {
+            if existing_outputs.check_fingerprint(&client) {
+                Ok(Self {
+                    client,
+                    outputs: existing_outputs,
+                    tx_history,
+                })
+            } else {
+                Err(Error::msg("outputs don't match client"))
+            }
+        } else {
+            // Create a new outputs list
+            let outputs = OutputList::new(
+                client.get_scan_key().public_key(&Secp256k1::signing_only()),
+                client.get_spend_key().into(),
+                0,
+            );
+            Ok(Self {
+                client,
+                outputs,
+                tx_history,
+            })
+        }
+    }
+
+    pub fn get_client(&self) -> &SpClient {
+        &self.client
+    }
+
+    pub fn get_outputs(&self) -> &OutputList {
+        &self.outputs
+    }
+
+    pub fn get_tx_history(&self) -> Vec<RecordedTransaction> {
+        self.tx_history.clone()
+    }
+
+    #[allow(dead_code)]
+    pub fn get_mut_client(&mut self) -> &mut SpClient {
+        &mut self.client
+    }
+
+    pub fn get_mut_outputs(&mut self) -> &mut OutputList {
+        &mut self.outputs
+    }
+
+    #[allow(dead_code)]
+    pub fn update_wallet_with_transaction(
+        &mut self,
+        tx: &Transaction,
+        blockheight: u32,
+        partial_tweak: PublicKey,
+    ) -> Result<HashMap<OutPoint, OwnedOutput>> {
+        // First check that we haven't already scanned this transaction
+        let txid = tx.txid();
+
+        for i in 0..tx.output.len() {
+            if self
+                .get_outputs()
+                .get_outpoint(OutPoint {
+                    txid,
+                    vout: i as u32,
+                })
+                .is_ok()
+            {
+                return Err(Error::msg("Transaction already scanned"));
+            }
+        }
+
+        for input in tx.input.iter() {
+            if let Ok((_, output)) = self.get_outputs().get_outpoint(input.previous_output) {
+                match output.spend_status {
+                    OutputSpendStatus::Spent(tx) => {
+                        if tx == txid.to_string() {
+                            return Err(Error::msg("Transaction already scanned"));
+                        }
+                    }
+                    OutputSpendStatus::Mined(_) => {
+                        return Err(Error::msg("Transaction already scanned"))
+                    }
+                    _ => continue,
+                }
+            }
+        }
+
+        let shared_secret = sp_utils::receiving::calculate_ecdh_shared_secret(
+            &partial_tweak,
+            &self.client.get_scan_key(),
+        );
+        let mut pubkeys_to_check: HashMap<XOnlyPublicKey, u32> = HashMap::new();
+        for (vout, output) in (0u32..).zip(tx.output.iter()) {
+            if output.script_pubkey.is_p2tr() {
+                let xonly = XOnlyPublicKey::from_slice(&output.script_pubkey.as_bytes()[2..])?;
+                pubkeys_to_check.insert(xonly, vout);
+            }
+        }
+        let ours = self
+            .client
+            .sp_receiver
+            .scan_transaction(&shared_secret, pubkeys_to_check.keys().cloned().collect())?;
+        let mut new_outputs: HashMap<OutPoint, OwnedOutput> = HashMap::new();
+        for (label, map) in ours {
+            for (key, scalar) in map {
+                let vout = pubkeys_to_check.get(&key).unwrap().to_owned();
+                let txout = tx.output.get(vout as usize).unwrap();
+
+                let label_str: Option<String>;
+                if let Some(ref l) = label {
+                    label_str = Some(l.as_string());
+                } else {
+                    label_str = None;
+                }
+
+                let outpoint = OutPoint::new(tx.txid(), vout);
+                let owned = OwnedOutput {
+                    blockheight,
+                    tweak: scalar.to_be_bytes().to_lower_hex_string(),
+                    amount: txout.value,
+                    script: txout.script_pubkey.as_bytes().to_lower_hex_string(),
+                    label: label_str,
+                    spend_status: OutputSpendStatus::Unspent,
+                };
+                new_outputs.insert(outpoint, owned);
+            }
+        }
+        let mut res = new_outputs.clone();
+        self.outputs.extend_from(new_outputs);
+
+        let txid = tx.txid().to_string();
+        // update outputs that we own and that are spent
+        for input in tx.input.iter() {
+            if let Some(prevout) = self.outputs.get_mut(&input.previous_output) {
+                // This is spent by this tx
+                prevout.spend_status = OutputSpendStatus::Spent(txid.clone());
+                res.insert(input.previous_output, prevout.clone());
+            }
+        }
+
+        Ok(res)
+    }
+
+    pub fn record_outgoing_transaction(
+        &mut self,
+        txid: Txid,
+        spent_outpoints: Vec<OutPoint>,
+        recipients: Vec<Recipient>,
+        change: Amount,
+    ) {
+        self.tx_history
+            .push(RecordedTransaction::Outgoing(RecordedTransactionOutgoing {
+                txid,
+                spent_outpoints,
+                recipients,
+                confirmed_at: None,
+                change,
+            }))
+    }
+
+    pub fn confirm_recorded_outgoing_transaction(
+        &mut self,
+        outpoint: OutPoint,
+        blkheight: Height,
+    ) -> Result<()> {
+        for recorded_tx in self.tx_history.iter_mut() {
+            match recorded_tx {
+                RecordedTransaction::Outgoing(outgoing)
+                    if (outgoing.spent_outpoints.contains(&outpoint)) =>
+                {
+                    outgoing.confirmed_at = Some(blkheight);
+                    return Ok(());
+                }
+                _ => (),
+            }
+        }
+
+        Err(Error::msg(format!(
+            "No outgoing tx found for input: {}",
+            outpoint
+        )))
+    }
+
+    pub fn record_incoming_transaction(
+        &mut self,
+        txid: Txid,
+        amount: Amount,
+        confirmed_at: Height,
+    ) {
+        self.tx_history
+            .push(RecordedTransaction::Incoming(RecordedTransactionIncoming {
+                txid,
+                amount,
+                confirmed_at: Some(confirmed_at),
+            }))
+    }
+
+    fn reset_to_height(&mut self, blkheight: u32) {
+        // reset known outputs to height
+        self.outputs.reset_to_height(blkheight);
+
+        // reset tx history to height
+        self.tx_history.retain(|tx| match tx {
+            RecordedTransaction::Incoming(incoming) => incoming
+                .confirmed_at
+                .is_some_and(|x| x.to_consensus_u32() < blkheight),
+            RecordedTransaction::Outgoing(outgoing) => outgoing
+                .confirmed_at
+                .is_some_and(|x| x.to_consensus_u32() < blkheight),
+        });
+    }
+
+    pub fn reset_to_birthday(&mut self) {
+        self.reset_to_height(self.outputs.get_birthday());
+
+        self.outputs.update_last_scan(self.outputs.get_birthday());
+    }
+
+    pub fn record_block_outputs(
+        &mut self,
+        height: Height,
+        found_outputs: HashMap<OutPoint, OwnedOutput>,
+    ) {
+        // add outputs to history
+        let mut txs: HashMap<Txid, Amount> = HashMap::new();
+        for (outpoint, output) in found_outputs.iter() {
+            let entry = txs.entry(outpoint.txid).or_default();
+            *entry += output.amount;
+        }
+        for (txid, amount) in txs {
+            self.tx_history
+                .push(RecordedTransaction::Incoming(RecordedTransactionIncoming {
+                    txid,
+                    amount,
+                    confirmed_at: Some(height),
+                }))
+        }
+
+        // add outputs to known outputs
+        self.outputs.extend_from(found_outputs);
+    }
+
+    pub fn record_block_inputs(
+        &mut self,
+        blkheight: Height,
+        blkhash: BlockHash,
+        found_inputs: Vec<OutPoint>,
+    ) -> Result<()> {
+        for outpoint in found_inputs {
+            // this may confirm the same tx multiple times, but this shouldn't be a problem
+            self.confirm_recorded_outgoing_transaction(outpoint, blkheight)?;
+            self.outputs.mark_mined(outpoint, blkhash)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn derive_keys_from_seed(seed: &[u8; 64], network: Network) -> Result<(SecretKey, SecretKey)> {
+    let xprv = Xpriv::new_master(network, seed)?;
+
+    let (scan_privkey, spend_privkey) = derive_keys_from_xprv(xprv)?;
+
+    Ok((scan_privkey, spend_privkey))
+}
+
+fn derive_keys_from_xprv(xprv: Xpriv) -> Result<(SecretKey, SecretKey)> {
+    let (scan_path, spend_path) = match xprv.network {
+        bitcoin::Network::Bitcoin => ("m/352h/0h/0h/1h/0", "m/352h/0h/0h/0h/0"),
+        _ => ("m/352h/1h/0h/1h/0", "m/352h/1h/0h/0h/0"),
+    };
+
+    let secp = Secp256k1::signing_only();
+    let scan_path = DerivationPath::from_str(scan_path)?;
+    let spend_path = DerivationPath::from_str(spend_path)?;
+    let scan_privkey = xprv.derive_priv(&secp, &scan_path)?.private_key;
+    let spend_privkey = xprv.derive_priv(&secp, &spend_path)?.private_key;
+
+    Ok((scan_privkey, spend_privkey))
+}


### PR DESCRIPTION
It does not make much sense to have all of the wallet logic (the transaction history, the owned outputs) inside of an sp client. This should be managed by the wallet instead. That's important, because for dana, we want to manage the tx history separately (probably store it in an sql database or something).

SpWallet still requires a lot of refactoring. Right now, too much of the logic is probably inside the Dana rust component. We should carefully try to move the relevant logic back to the sp client.