### PR TITLE
Move seed phrase from SpWallet data blob to flutter secure storage

### DIFF
--- a/lib/generated/rust/api/structs.dart
+++ b/lib/generated/rust/api/structs.dart
@@ -33,6 +33,69 @@ class Amount {
           field0 == other.field0;
 }
 
+class ApiSetupResult {
+  final String walletBlob;
+  final String? mnemonic;
+
+  const ApiSetupResult({
+    required this.walletBlob,
+    this.mnemonic,
+  });
+
+  @override
+  int get hashCode => walletBlob.hashCode ^ mnemonic.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiSetupResult &&
+          runtimeType == other.runtimeType &&
+          walletBlob == other.walletBlob &&
+          mnemonic == other.mnemonic;
+}
+
+class ApiSetupWalletArgs {
+  final ApiSetupWalletType setupType;
+  final int birthday;
+  final String network;
+
+  const ApiSetupWalletArgs({
+    required this.setupType,
+    required this.birthday,
+    required this.network,
+  });
+
+  @override
+  int get hashCode => setupType.hashCode ^ birthday.hashCode ^ network.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiSetupWalletArgs &&
+          runtimeType == other.runtimeType &&
+          setupType == other.setupType &&
+          birthday == other.birthday &&
+          network == other.network;
+}
+
+@freezed
+sealed class ApiSetupWalletType with _$ApiSetupWalletType {
+  const ApiSetupWalletType._();
+
+  const factory ApiSetupWalletType.newWallet() = ApiSetupWalletType_NewWallet;
+  const factory ApiSetupWalletType.mnemonic(
+    String field0,
+  ) = ApiSetupWalletType_Mnemonic;
+  const factory ApiSetupWalletType.full(
+    String field0,
+    String field1,
+  ) = ApiSetupWalletType_Full;
+  const factory ApiSetupWalletType.watchOnly(
+    String field0,
+    String field1,
+  ) = ApiSetupWalletType_WatchOnly;
+}
+
 @freezed
 sealed class OutputSpendStatus with _$OutputSpendStatus {
   const OutputSpendStatus._();

--- a/lib/generated/rust/api/structs.freezed.dart
+++ b/lib/generated/rust/api/structs.freezed.dart
@@ -15,6 +15,700 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
+mixin _$ApiSetupWalletType {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() newWallet,
+    required TResult Function(String field0) mnemonic,
+    required TResult Function(String field0, String field1) full,
+    required TResult Function(String field0, String field1) watchOnly,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? newWallet,
+    TResult? Function(String field0)? mnemonic,
+    TResult? Function(String field0, String field1)? full,
+    TResult? Function(String field0, String field1)? watchOnly,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? newWallet,
+    TResult Function(String field0)? mnemonic,
+    TResult Function(String field0, String field1)? full,
+    TResult Function(String field0, String field1)? watchOnly,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ApiSetupWalletType_NewWallet value) newWallet,
+    required TResult Function(ApiSetupWalletType_Mnemonic value) mnemonic,
+    required TResult Function(ApiSetupWalletType_Full value) full,
+    required TResult Function(ApiSetupWalletType_WatchOnly value) watchOnly,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult? Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult? Function(ApiSetupWalletType_Full value)? full,
+    TResult? Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult Function(ApiSetupWalletType_Full value)? full,
+    TResult Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiSetupWalletTypeCopyWith<$Res> {
+  factory $ApiSetupWalletTypeCopyWith(
+          ApiSetupWalletType value, $Res Function(ApiSetupWalletType) then) =
+      _$ApiSetupWalletTypeCopyWithImpl<$Res, ApiSetupWalletType>;
+}
+
+/// @nodoc
+class _$ApiSetupWalletTypeCopyWithImpl<$Res, $Val extends ApiSetupWalletType>
+    implements $ApiSetupWalletTypeCopyWith<$Res> {
+  _$ApiSetupWalletTypeCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$ApiSetupWalletType_NewWalletImplCopyWith<$Res> {
+  factory _$$ApiSetupWalletType_NewWalletImplCopyWith(
+          _$ApiSetupWalletType_NewWalletImpl value,
+          $Res Function(_$ApiSetupWalletType_NewWalletImpl) then) =
+      __$$ApiSetupWalletType_NewWalletImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$ApiSetupWalletType_NewWalletImplCopyWithImpl<$Res>
+    extends _$ApiSetupWalletTypeCopyWithImpl<$Res,
+        _$ApiSetupWalletType_NewWalletImpl>
+    implements _$$ApiSetupWalletType_NewWalletImplCopyWith<$Res> {
+  __$$ApiSetupWalletType_NewWalletImplCopyWithImpl(
+      _$ApiSetupWalletType_NewWalletImpl _value,
+      $Res Function(_$ApiSetupWalletType_NewWalletImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$ApiSetupWalletType_NewWalletImpl extends ApiSetupWalletType_NewWallet {
+  const _$ApiSetupWalletType_NewWalletImpl() : super._();
+
+  @override
+  String toString() {
+    return 'ApiSetupWalletType.newWallet()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiSetupWalletType_NewWalletImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() newWallet,
+    required TResult Function(String field0) mnemonic,
+    required TResult Function(String field0, String field1) full,
+    required TResult Function(String field0, String field1) watchOnly,
+  }) {
+    return newWallet();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? newWallet,
+    TResult? Function(String field0)? mnemonic,
+    TResult? Function(String field0, String field1)? full,
+    TResult? Function(String field0, String field1)? watchOnly,
+  }) {
+    return newWallet?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? newWallet,
+    TResult Function(String field0)? mnemonic,
+    TResult Function(String field0, String field1)? full,
+    TResult Function(String field0, String field1)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (newWallet != null) {
+      return newWallet();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ApiSetupWalletType_NewWallet value) newWallet,
+    required TResult Function(ApiSetupWalletType_Mnemonic value) mnemonic,
+    required TResult Function(ApiSetupWalletType_Full value) full,
+    required TResult Function(ApiSetupWalletType_WatchOnly value) watchOnly,
+  }) {
+    return newWallet(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult? Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult? Function(ApiSetupWalletType_Full value)? full,
+    TResult? Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+  }) {
+    return newWallet?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult Function(ApiSetupWalletType_Full value)? full,
+    TResult Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (newWallet != null) {
+      return newWallet(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ApiSetupWalletType_NewWallet extends ApiSetupWalletType {
+  const factory ApiSetupWalletType_NewWallet() =
+      _$ApiSetupWalletType_NewWalletImpl;
+  const ApiSetupWalletType_NewWallet._() : super._();
+}
+
+/// @nodoc
+abstract class _$$ApiSetupWalletType_MnemonicImplCopyWith<$Res> {
+  factory _$$ApiSetupWalletType_MnemonicImplCopyWith(
+          _$ApiSetupWalletType_MnemonicImpl value,
+          $Res Function(_$ApiSetupWalletType_MnemonicImpl) then) =
+      __$$ApiSetupWalletType_MnemonicImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String field0});
+}
+
+/// @nodoc
+class __$$ApiSetupWalletType_MnemonicImplCopyWithImpl<$Res>
+    extends _$ApiSetupWalletTypeCopyWithImpl<$Res,
+        _$ApiSetupWalletType_MnemonicImpl>
+    implements _$$ApiSetupWalletType_MnemonicImplCopyWith<$Res> {
+  __$$ApiSetupWalletType_MnemonicImplCopyWithImpl(
+      _$ApiSetupWalletType_MnemonicImpl _value,
+      $Res Function(_$ApiSetupWalletType_MnemonicImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(_$ApiSetupWalletType_MnemonicImpl(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ApiSetupWalletType_MnemonicImpl extends ApiSetupWalletType_Mnemonic {
+  const _$ApiSetupWalletType_MnemonicImpl(this.field0) : super._();
+
+  @override
+  final String field0;
+
+  @override
+  String toString() {
+    return 'ApiSetupWalletType.mnemonic(field0: $field0)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiSetupWalletType_MnemonicImpl &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ApiSetupWalletType_MnemonicImplCopyWith<_$ApiSetupWalletType_MnemonicImpl>
+      get copyWith => __$$ApiSetupWalletType_MnemonicImplCopyWithImpl<
+          _$ApiSetupWalletType_MnemonicImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() newWallet,
+    required TResult Function(String field0) mnemonic,
+    required TResult Function(String field0, String field1) full,
+    required TResult Function(String field0, String field1) watchOnly,
+  }) {
+    return mnemonic(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? newWallet,
+    TResult? Function(String field0)? mnemonic,
+    TResult? Function(String field0, String field1)? full,
+    TResult? Function(String field0, String field1)? watchOnly,
+  }) {
+    return mnemonic?.call(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? newWallet,
+    TResult Function(String field0)? mnemonic,
+    TResult Function(String field0, String field1)? full,
+    TResult Function(String field0, String field1)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (mnemonic != null) {
+      return mnemonic(field0);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ApiSetupWalletType_NewWallet value) newWallet,
+    required TResult Function(ApiSetupWalletType_Mnemonic value) mnemonic,
+    required TResult Function(ApiSetupWalletType_Full value) full,
+    required TResult Function(ApiSetupWalletType_WatchOnly value) watchOnly,
+  }) {
+    return mnemonic(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult? Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult? Function(ApiSetupWalletType_Full value)? full,
+    TResult? Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+  }) {
+    return mnemonic?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult Function(ApiSetupWalletType_Full value)? full,
+    TResult Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (mnemonic != null) {
+      return mnemonic(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ApiSetupWalletType_Mnemonic extends ApiSetupWalletType {
+  const factory ApiSetupWalletType_Mnemonic(final String field0) =
+      _$ApiSetupWalletType_MnemonicImpl;
+  const ApiSetupWalletType_Mnemonic._() : super._();
+
+  String get field0;
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ApiSetupWalletType_MnemonicImplCopyWith<_$ApiSetupWalletType_MnemonicImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ApiSetupWalletType_FullImplCopyWith<$Res> {
+  factory _$$ApiSetupWalletType_FullImplCopyWith(
+          _$ApiSetupWalletType_FullImpl value,
+          $Res Function(_$ApiSetupWalletType_FullImpl) then) =
+      __$$ApiSetupWalletType_FullImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String field0, String field1});
+}
+
+/// @nodoc
+class __$$ApiSetupWalletType_FullImplCopyWithImpl<$Res>
+    extends _$ApiSetupWalletTypeCopyWithImpl<$Res,
+        _$ApiSetupWalletType_FullImpl>
+    implements _$$ApiSetupWalletType_FullImplCopyWith<$Res> {
+  __$$ApiSetupWalletType_FullImplCopyWithImpl(
+      _$ApiSetupWalletType_FullImpl _value,
+      $Res Function(_$ApiSetupWalletType_FullImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+    Object? field1 = null,
+  }) {
+    return _then(_$ApiSetupWalletType_FullImpl(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == field1
+          ? _value.field1
+          : field1 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ApiSetupWalletType_FullImpl extends ApiSetupWalletType_Full {
+  const _$ApiSetupWalletType_FullImpl(this.field0, this.field1) : super._();
+
+  @override
+  final String field0;
+  @override
+  final String field1;
+
+  @override
+  String toString() {
+    return 'ApiSetupWalletType.full(field0: $field0, field1: $field1)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiSetupWalletType_FullImpl &&
+            (identical(other.field0, field0) || other.field0 == field0) &&
+            (identical(other.field1, field1) || other.field1 == field1));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0, field1);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ApiSetupWalletType_FullImplCopyWith<_$ApiSetupWalletType_FullImpl>
+      get copyWith => __$$ApiSetupWalletType_FullImplCopyWithImpl<
+          _$ApiSetupWalletType_FullImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() newWallet,
+    required TResult Function(String field0) mnemonic,
+    required TResult Function(String field0, String field1) full,
+    required TResult Function(String field0, String field1) watchOnly,
+  }) {
+    return full(field0, field1);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? newWallet,
+    TResult? Function(String field0)? mnemonic,
+    TResult? Function(String field0, String field1)? full,
+    TResult? Function(String field0, String field1)? watchOnly,
+  }) {
+    return full?.call(field0, field1);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? newWallet,
+    TResult Function(String field0)? mnemonic,
+    TResult Function(String field0, String field1)? full,
+    TResult Function(String field0, String field1)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (full != null) {
+      return full(field0, field1);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ApiSetupWalletType_NewWallet value) newWallet,
+    required TResult Function(ApiSetupWalletType_Mnemonic value) mnemonic,
+    required TResult Function(ApiSetupWalletType_Full value) full,
+    required TResult Function(ApiSetupWalletType_WatchOnly value) watchOnly,
+  }) {
+    return full(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult? Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult? Function(ApiSetupWalletType_Full value)? full,
+    TResult? Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+  }) {
+    return full?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult Function(ApiSetupWalletType_Full value)? full,
+    TResult Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (full != null) {
+      return full(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ApiSetupWalletType_Full extends ApiSetupWalletType {
+  const factory ApiSetupWalletType_Full(
+      final String field0, final String field1) = _$ApiSetupWalletType_FullImpl;
+  const ApiSetupWalletType_Full._() : super._();
+
+  String get field0;
+  String get field1;
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ApiSetupWalletType_FullImplCopyWith<_$ApiSetupWalletType_FullImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ApiSetupWalletType_WatchOnlyImplCopyWith<$Res> {
+  factory _$$ApiSetupWalletType_WatchOnlyImplCopyWith(
+          _$ApiSetupWalletType_WatchOnlyImpl value,
+          $Res Function(_$ApiSetupWalletType_WatchOnlyImpl) then) =
+      __$$ApiSetupWalletType_WatchOnlyImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String field0, String field1});
+}
+
+/// @nodoc
+class __$$ApiSetupWalletType_WatchOnlyImplCopyWithImpl<$Res>
+    extends _$ApiSetupWalletTypeCopyWithImpl<$Res,
+        _$ApiSetupWalletType_WatchOnlyImpl>
+    implements _$$ApiSetupWalletType_WatchOnlyImplCopyWith<$Res> {
+  __$$ApiSetupWalletType_WatchOnlyImplCopyWithImpl(
+      _$ApiSetupWalletType_WatchOnlyImpl _value,
+      $Res Function(_$ApiSetupWalletType_WatchOnlyImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+    Object? field1 = null,
+  }) {
+    return _then(_$ApiSetupWalletType_WatchOnlyImpl(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == field1
+          ? _value.field1
+          : field1 // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ApiSetupWalletType_WatchOnlyImpl extends ApiSetupWalletType_WatchOnly {
+  const _$ApiSetupWalletType_WatchOnlyImpl(this.field0, this.field1)
+      : super._();
+
+  @override
+  final String field0;
+  @override
+  final String field1;
+
+  @override
+  String toString() {
+    return 'ApiSetupWalletType.watchOnly(field0: $field0, field1: $field1)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiSetupWalletType_WatchOnlyImpl &&
+            (identical(other.field0, field0) || other.field0 == field0) &&
+            (identical(other.field1, field1) || other.field1 == field1));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0, field1);
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ApiSetupWalletType_WatchOnlyImplCopyWith<
+          _$ApiSetupWalletType_WatchOnlyImpl>
+      get copyWith => __$$ApiSetupWalletType_WatchOnlyImplCopyWithImpl<
+          _$ApiSetupWalletType_WatchOnlyImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() newWallet,
+    required TResult Function(String field0) mnemonic,
+    required TResult Function(String field0, String field1) full,
+    required TResult Function(String field0, String field1) watchOnly,
+  }) {
+    return watchOnly(field0, field1);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? newWallet,
+    TResult? Function(String field0)? mnemonic,
+    TResult? Function(String field0, String field1)? full,
+    TResult? Function(String field0, String field1)? watchOnly,
+  }) {
+    return watchOnly?.call(field0, field1);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? newWallet,
+    TResult Function(String field0)? mnemonic,
+    TResult Function(String field0, String field1)? full,
+    TResult Function(String field0, String field1)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (watchOnly != null) {
+      return watchOnly(field0, field1);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ApiSetupWalletType_NewWallet value) newWallet,
+    required TResult Function(ApiSetupWalletType_Mnemonic value) mnemonic,
+    required TResult Function(ApiSetupWalletType_Full value) full,
+    required TResult Function(ApiSetupWalletType_WatchOnly value) watchOnly,
+  }) {
+    return watchOnly(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult? Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult? Function(ApiSetupWalletType_Full value)? full,
+    TResult? Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+  }) {
+    return watchOnly?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ApiSetupWalletType_NewWallet value)? newWallet,
+    TResult Function(ApiSetupWalletType_Mnemonic value)? mnemonic,
+    TResult Function(ApiSetupWalletType_Full value)? full,
+    TResult Function(ApiSetupWalletType_WatchOnly value)? watchOnly,
+    required TResult orElse(),
+  }) {
+    if (watchOnly != null) {
+      return watchOnly(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ApiSetupWalletType_WatchOnly extends ApiSetupWalletType {
+  const factory ApiSetupWalletType_WatchOnly(
+          final String field0, final String field1) =
+      _$ApiSetupWalletType_WatchOnlyImpl;
+  const ApiSetupWalletType_WatchOnly._() : super._();
+
+  String get field0;
+  String get field1;
+
+  /// Create a copy of ApiSetupWalletType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ApiSetupWalletType_WatchOnlyImplCopyWith<
+          _$ApiSetupWalletType_WatchOnlyImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
 mixin _$OutputSpendStatus {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({

--- a/lib/generated/rust/api/wallet.dart
+++ b/lib/generated/rust/api/wallet.dart
@@ -8,18 +8,8 @@ import '../lib.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'structs.dart';
 
-Future<String> setup(
-        {String? mnemonic,
-        String? scanKey,
-        String? spendKey,
-        required int birthday,
-        required String network}) =>
-    RustLib.instance.api.crateApiWalletSetup(
-        mnemonic: mnemonic,
-        scanKey: scanKey,
-        spendKey: spendKey,
-        birthday: birthday,
-        network: network);
+ApiSetupResult setupWallet({required ApiSetupWalletArgs setupArgs}) =>
+    RustLib.instance.api.crateApiWalletSetupWallet(setupArgs: setupArgs);
 
 /// Change wallet birthday
 /// Reset the output list and last_scan
@@ -63,6 +53,3 @@ String addOutgoingTxToHistory(
         spentOutpoints: spentOutpoints,
         recipients: recipients,
         change: change);
-
-String? showMnemonic({required String encodedWallet}) => RustLib.instance.api
-    .crateApiWalletShowMnemonic(encodedWallet: encodedWallet);

--- a/lib/generated/rust/api/wallet.dart
+++ b/lib/generated/rust/api/wallet.dart
@@ -9,14 +9,12 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'structs.dart';
 
 Future<String> setup(
-        {required String label,
-        String? mnemonic,
+        {String? mnemonic,
         String? scanKey,
         String? spendKey,
         required int birthday,
         required String network}) =>
     RustLib.instance.api.crateApiWalletSetup(
-        label: label,
         mnemonic: mnemonic,
         scanKey: scanKey,
         spendKey: spendKey,

--- a/lib/generated/rust/frb_generated.dart
+++ b/lib/generated/rust/frb_generated.dart
@@ -154,8 +154,7 @@ abstract class RustLibApi extends BaseApi {
       required String encodedWallet});
 
   Future<String> crateApiWalletSetup(
-      {required String label,
-      String? mnemonic,
+      {String? mnemonic,
       String? scanKey,
       String? spendKey,
       required int birthday,
@@ -732,8 +731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<String> crateApiWalletSetup(
-      {required String label,
-      String? mnemonic,
+      {String? mnemonic,
       String? scanKey,
       String? spendKey,
       required int birthday,
@@ -741,7 +739,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_String(label, serializer);
         sse_encode_opt_String(mnemonic, serializer);
         sse_encode_opt_String(scanKey, serializer);
         sse_encode_opt_String(spendKey, serializer);
@@ -755,21 +752,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiWalletSetupConstMeta,
-      argValues: [label, mnemonic, scanKey, spendKey, birthday, network],
+      argValues: [mnemonic, scanKey, spendKey, birthday, network],
       apiImpl: this,
     ));
   }
 
   TaskConstMeta get kCrateApiWalletSetupConstMeta => const TaskConstMeta(
         debugName: "setup",
-        argNames: [
-          "label",
-          "mnemonic",
-          "scanKey",
-          "spendKey",
-          "birthday",
-          "network"
-        ],
+        argNames: ["mnemonic", "scanKey", "spendKey", "birthday", "network"],
       );
 
   @override

--- a/lib/generated/rust/frb_generated.io.dart
+++ b/lib/generated/rust/frb_generated.io.dart
@@ -48,10 +48,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Amount dco_decode_amount(dynamic raw);
 
   @protected
+  ApiSetupResult dco_decode_api_setup_result(dynamic raw);
+
+  @protected
+  ApiSetupWalletArgs dco_decode_api_setup_wallet_args(dynamic raw);
+
+  @protected
+  ApiSetupWalletType dco_decode_api_setup_wallet_type(dynamic raw);
+
+  @protected
   bool dco_decode_bool(dynamic raw);
 
   @protected
   Amount dco_decode_box_autoadd_amount(dynamic raw);
+
+  @protected
+  ApiSetupWalletArgs dco_decode_box_autoadd_api_setup_wallet_args(dynamic raw);
 
   @protected
   RecordedTransactionIncoming
@@ -183,10 +195,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Amount sse_decode_amount(SseDeserializer deserializer);
 
   @protected
+  ApiSetupResult sse_decode_api_setup_result(SseDeserializer deserializer);
+
+  @protected
+  ApiSetupWalletArgs sse_decode_api_setup_wallet_args(
+      SseDeserializer deserializer);
+
+  @protected
+  ApiSetupWalletType sse_decode_api_setup_wallet_type(
+      SseDeserializer deserializer);
+
+  @protected
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
   Amount sse_decode_box_autoadd_amount(SseDeserializer deserializer);
+
+  @protected
+  ApiSetupWalletArgs sse_decode_box_autoadd_api_setup_wallet_args(
+      SseDeserializer deserializer);
 
   @protected
   RecordedTransactionIncoming
@@ -326,10 +353,26 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_amount(Amount self, SseSerializer serializer);
 
   @protected
+  void sse_encode_api_setup_result(
+      ApiSetupResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_api_setup_wallet_args(
+      ApiSetupWalletArgs self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_api_setup_wallet_type(
+      ApiSetupWalletType self, SseSerializer serializer);
+
+  @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_amount(Amount self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_api_setup_wallet_args(
+      ApiSetupWalletArgs self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_recorded_transaction_incoming(

--- a/lib/generated/rust/frb_generated.web.dart
+++ b/lib/generated/rust/frb_generated.web.dart
@@ -50,10 +50,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Amount dco_decode_amount(dynamic raw);
 
   @protected
+  ApiSetupResult dco_decode_api_setup_result(dynamic raw);
+
+  @protected
+  ApiSetupWalletArgs dco_decode_api_setup_wallet_args(dynamic raw);
+
+  @protected
+  ApiSetupWalletType dco_decode_api_setup_wallet_type(dynamic raw);
+
+  @protected
   bool dco_decode_bool(dynamic raw);
 
   @protected
   Amount dco_decode_box_autoadd_amount(dynamic raw);
+
+  @protected
+  ApiSetupWalletArgs dco_decode_box_autoadd_api_setup_wallet_args(dynamic raw);
 
   @protected
   RecordedTransactionIncoming
@@ -185,10 +197,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Amount sse_decode_amount(SseDeserializer deserializer);
 
   @protected
+  ApiSetupResult sse_decode_api_setup_result(SseDeserializer deserializer);
+
+  @protected
+  ApiSetupWalletArgs sse_decode_api_setup_wallet_args(
+      SseDeserializer deserializer);
+
+  @protected
+  ApiSetupWalletType sse_decode_api_setup_wallet_type(
+      SseDeserializer deserializer);
+
+  @protected
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
   Amount sse_decode_box_autoadd_amount(SseDeserializer deserializer);
+
+  @protected
+  ApiSetupWalletArgs sse_decode_box_autoadd_api_setup_wallet_args(
+      SseDeserializer deserializer);
 
   @protected
   RecordedTransactionIncoming
@@ -328,10 +355,26 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_amount(Amount self, SseSerializer serializer);
 
   @protected
+  void sse_encode_api_setup_result(
+      ApiSetupResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_api_setup_wallet_args(
+      ApiSetupWalletArgs self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_api_setup_wallet_type(
+      ApiSetupWalletType self, SseSerializer serializer);
+
+  @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_amount(Amount self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_api_setup_wallet_args(
+      ApiSetupWalletArgs self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_recorded_transaction_incoming(

--- a/lib/repositories/wallet_repository.dart
+++ b/lib/repositories/wallet_repository.dart
@@ -2,9 +2,14 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class WalletRepository {
   final String keyWalletBlob = "wallet";
+  final String keySeedPhrase = "seedphrase";
   final secureStorage = const FlutterSecureStorage();
 
   WalletRepository();
+
+  Future<void> reset() async {
+    await secureStorage.deleteAll();
+  }
 
   Future<String?> readWalletBlob() async {
     return await secureStorage.read(key: keyWalletBlob);
@@ -14,7 +19,11 @@ class WalletRepository {
     await secureStorage.write(key: keyWalletBlob, value: wallet);
   }
 
-  Future<void> deleteWalletBlob() async {
-    await secureStorage.write(key: keyWalletBlob, value: null);
+  Future<String?> readSeedPhrase() async {
+    return await secureStorage.read(key: keySeedPhrase);
+  }
+
+  Future<void> saveSeedPhrase(String seedPhrase) async {
+    await secureStorage.write(key: keySeedPhrase, value: seedPhrase);
   }
 }

--- a/lib/repositories/wallet_repository.dart
+++ b/lib/repositories/wallet_repository.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class WalletRepository {
-  final String keyWalletBlob = "default";
+  final String keyWalletBlob = "wallet";
   final secureStorage = const FlutterSecureStorage();
 
   WalletRepository();

--- a/lib/repositories/wallet_repository.dart
+++ b/lib/repositories/wallet_repository.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class WalletRepository {
+  final String keyWalletBlob = "default";
+  final secureStorage = const FlutterSecureStorage();
+
+  WalletRepository();
+
+  Future<String?> readWalletBlob() async {
+    return await secureStorage.read(key: keyWalletBlob);
+  }
+
+  Future<void> saveWalletBlob(String wallet) async {
+    await secureStorage.write(key: keyWalletBlob, value: wallet);
+  }
+
+  Future<void> deleteWalletBlob() async {
+    await secureStorage.write(key: keyWalletBlob, value: null);
+  }
+}

--- a/lib/screens/create/create_wallet.dart
+++ b/lib/screens/create/create_wallet.dart
@@ -73,7 +73,6 @@ class CreateWalletScreenState extends State<CreateWalletScreen> {
 
     try {
       final wallet = await setup(
-        label: walletState.label,
         mnemonic: mnemonic,
         scanKey: scanKey,
         spendKey: spendKey,

--- a/lib/screens/home/settings/settings.dart
+++ b/lib/screens/home/settings/settings.dart
@@ -21,7 +21,6 @@ class SettingsScreen extends StatelessWidget {
     ThemeNotifier themeNotifier,
   ) async {
     try {
-      await walletState.rmWalletFromSecureStorage();
       await walletState.reset();
 
       await SettingsService().resetAll();
@@ -30,16 +29,6 @@ class SettingsScreen extends StatelessWidget {
       themeNotifier.setTheme(null);
     } catch (e) {
       rethrow;
-    }
-  }
-
-  Future<String?> _getSeedPhrase(WalletState walletState) async {
-    try {
-      final wallet = await walletState.getWalletFromSecureStorage();
-      return showMnemonic(encodedWallet: wallet);
-    } catch (e) {
-      displayNotification(exceptionToString(e));
-      return null;
     }
   }
 
@@ -114,7 +103,7 @@ class SettingsScreen extends StatelessWidget {
             title: 'Show seed phrase',
             onPressed: () async {
               const title = 'Backup seed phrase';
-              final text = await _getSeedPhrase(walletState) ??
+              final text = await walletState.getSeedPhrase() ??
                   'Seed phrase unknown! Did you import from keys?';
 
               showAlertDialog(title, text);

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -98,6 +98,8 @@ class WalletState extends ChangeNotifier {
   }
 
   Future<void> reset() async {
+    await walletRepository.reset();
+
     amount = BigInt.zero;
     network = Network.signet;
     birthday = 0;
@@ -115,8 +117,8 @@ class WalletState extends ChangeNotifier {
     await walletRepository.saveWalletBlob(wallet);
   }
 
-  Future<void> rmWalletFromSecureStorage() async {
-    await walletRepository.deleteWalletBlob();
+  Future<void> saveSeedPhraseToSecureStorage(String seedphrase) async {
+    await walletRepository.saveSeedPhrase(seedphrase);
   }
 
   Future<String> getWalletFromSecureStorage() async {
@@ -126,6 +128,10 @@ class WalletState extends ChangeNotifier {
     } else {
       throw Exception("No wallet in storage");
     }
+  }
+
+  Future<String?> getSeedPhrase() async {
+    return await walletRepository.readSeedPhrase();
   }
 
   Future<void> updateWalletStatus() async {

--- a/rust/src/api/structs.rs
+++ b/rust/src/api/structs.rs
@@ -252,3 +252,21 @@ pub struct WalletStatus {
     pub outputs: HashMap<String, OwnedOutput>,
     pub tx_history: Vec<RecordedTransaction>,
 }
+
+pub struct ApiSetupWalletArgs {
+    pub setup_type: ApiSetupWalletType,
+    pub birthday: u32,
+    pub network: String,
+}
+
+pub enum ApiSetupWalletType {
+    NewWallet,
+    Mnemonic(String),
+    Full(String, String),
+    WatchOnly(String, String),
+}
+
+pub struct ApiSetupResult {
+    pub wallet_blob: String,
+    pub mnemonic: Option<String>,
+}

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -17,7 +17,6 @@ use super::structs::{Amount, Recipient, WalletStatus};
 const PASSPHRASE: &str = ""; // no passphrase for now
 
 pub async fn setup(
-    label: String,
     mnemonic: Option<String>,
     scan_key: Option<String>,
     spend_key: Option<String>,
@@ -36,7 +35,7 @@ pub async fn setup(
             let (scan_sk, spend_sk) = derive_keys_from_seed(&seed, network)?;
             sp_client = SpClient::new(scan_sk, SpendKey::Secret(spend_sk), network)?;
 
-            let sp_wallet = SpWallet::new(sp_client, birthday, Some(m.to_string()), label).unwrap();
+            let sp_wallet = SpWallet::new(sp_client, birthday, Some(m.to_string())).unwrap();
             Ok(serde_json::to_string(&sp_wallet).unwrap())
         }
         (mnemonic, None, None) => {
@@ -46,7 +45,7 @@ pub async fn setup(
             let (scan_sk, spend_sk) = derive_keys_from_seed(&seed, network)?;
             sp_client = SpClient::new(scan_sk, SpendKey::Secret(spend_sk), network)?;
 
-            let sp_wallet = SpWallet::new(sp_client, birthday, mnemonic, label).unwrap();
+            let sp_wallet = SpWallet::new(sp_client, birthday, mnemonic).unwrap();
             Ok(serde_json::to_string(&sp_wallet).unwrap())
         }
         (None, scan_sk_hex, spend_key_hex) => {
@@ -60,7 +59,7 @@ pub async fn setup(
                 return Err(Error::msg("Can't parse spend key".to_owned()));
             }
 
-            let sp_wallet = SpWallet::new(sp_client, birthday, None, label).unwrap();
+            let sp_wallet = SpWallet::new(sp_client, birthday, None).unwrap();
             Ok(serde_json::to_string(&sp_wallet).unwrap())
         }
         _ => Err(Error::msg(

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -812,7 +812,6 @@ fn wire__crate__api__wallet__setup_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_label = <String>::sse_decode(&mut deserializer);
             let api_mnemonic = <Option<String>>::sse_decode(&mut deserializer);
             let api_scan_key = <Option<String>>::sse_decode(&mut deserializer);
             let api_spend_key = <Option<String>>::sse_decode(&mut deserializer);
@@ -823,7 +822,6 @@ fn wire__crate__api__wallet__setup_impl(
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || async move {
                         let output_ok = crate::api::wallet::setup(
-                            api_label,
                             api_mnemonic,
                             api_scan_key,
                             api_spend_key,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.3.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 141683958;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1563776657;
 
 // Section: executor
 
@@ -790,61 +790,14 @@ fn wire__crate__api__wallet__scan_to_tip_impl(
         },
     )
 }
-fn wire__crate__api__wallet__setup_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "setup",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_mnemonic = <Option<String>>::sse_decode(&mut deserializer);
-            let api_scan_key = <Option<String>>::sse_decode(&mut deserializer);
-            let api_spend_key = <Option<String>>::sse_decode(&mut deserializer);
-            let api_birthday = <u32>::sse_decode(&mut deserializer);
-            let api_network = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet::setup(
-                            api_mnemonic,
-                            api_scan_key,
-                            api_spend_key,
-                            api_birthday,
-                            api_network,
-                        )
-                        .await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__wallet__show_mnemonic_impl(
+fn wire__crate__api__wallet__setup_wallet_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "show_mnemonic",
+            debug_name: "setup_wallet",
             port: None,
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
@@ -858,11 +811,12 @@ fn wire__crate__api__wallet__show_mnemonic_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_encoded_wallet = <String>::sse_decode(&mut deserializer);
+            let api_setup_args =
+                <crate::api::structs::ApiSetupWalletArgs>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                 (move || {
-                    let output_ok = crate::api::wallet::show_mnemonic(api_encoded_wallet)?;
+                    let output_ok = crate::api::wallet::setup_wallet(api_setup_args)?;
                     Ok(output_ok)
                 })(),
             )
@@ -931,6 +885,61 @@ impl SseDecode for crate::api::structs::Amount {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 = <u64>::sse_decode(deserializer);
         return crate::api::structs::Amount(var_field0);
+    }
+}
+
+impl SseDecode for crate::api::structs::ApiSetupResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletBlob = <String>::sse_decode(deserializer);
+        let mut var_mnemonic = <Option<String>>::sse_decode(deserializer);
+        return crate::api::structs::ApiSetupResult {
+            wallet_blob: var_walletBlob,
+            mnemonic: var_mnemonic,
+        };
+    }
+}
+
+impl SseDecode for crate::api::structs::ApiSetupWalletArgs {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_setupType = <crate::api::structs::ApiSetupWalletType>::sse_decode(deserializer);
+        let mut var_birthday = <u32>::sse_decode(deserializer);
+        let mut var_network = <String>::sse_decode(deserializer);
+        return crate::api::structs::ApiSetupWalletArgs {
+            setup_type: var_setupType,
+            birthday: var_birthday,
+            network: var_network,
+        };
+    }
+}
+
+impl SseDecode for crate::api::structs::ApiSetupWalletType {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::structs::ApiSetupWalletType::NewWallet;
+            }
+            1 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::api::structs::ApiSetupWalletType::Mnemonic(var_field0);
+            }
+            2 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                let mut var_field1 = <String>::sse_decode(deserializer);
+                return crate::api::structs::ApiSetupWalletType::Full(var_field0, var_field1);
+            }
+            3 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                let mut var_field1 = <String>::sse_decode(deserializer);
+                return crate::api::structs::ApiSetupWalletType::WatchOnly(var_field0, var_field1);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -1317,7 +1326,6 @@ fn pde_ffi_dispatcher_primary_impl(
         3 => wire__crate__api__psbt__broadcast_tx_impl(port, ptr, rust_vec_len, data_len),
         9 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
         21 => wire__crate__api__wallet__scan_to_tip_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet__setup_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1359,7 +1367,7 @@ fn pde_ffi_dispatcher_sync_impl(
         18 => wire__crate__api__wallet__get_wallet_info_impl(ptr, rust_vec_len, data_len),
         19 => wire__crate__api__wallet__mark_outpoints_spent_impl(ptr, rust_vec_len, data_len),
         20 => wire__crate__api__wallet__reset_wallet_impl(ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__wallet__show_mnemonic_impl(ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__wallet__setup_wallet_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1377,6 +1385,86 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::structs::Amount>
     for crate::api::structs::Amount
 {
     fn into_into_dart(self) -> crate::api::structs::Amount {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::structs::ApiSetupResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_blob.into_into_dart().into_dart(),
+            self.mnemonic.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::structs::ApiSetupResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::structs::ApiSetupResult>
+    for crate::api::structs::ApiSetupResult
+{
+    fn into_into_dart(self) -> crate::api::structs::ApiSetupResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::structs::ApiSetupWalletArgs {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.setup_type.into_into_dart().into_dart(),
+            self.birthday.into_into_dart().into_dart(),
+            self.network.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::structs::ApiSetupWalletArgs
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::structs::ApiSetupWalletArgs>
+    for crate::api::structs::ApiSetupWalletArgs
+{
+    fn into_into_dart(self) -> crate::api::structs::ApiSetupWalletArgs {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::structs::ApiSetupWalletType {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::structs::ApiSetupWalletType::NewWallet => [0.into_dart()].into_dart(),
+            crate::api::structs::ApiSetupWalletType::Mnemonic(field0) => {
+                [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::structs::ApiSetupWalletType::Full(field0, field1) => [
+                2.into_dart(),
+                field0.into_into_dart().into_dart(),
+                field1.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::structs::ApiSetupWalletType::WatchOnly(field0, field1) => [
+                3.into_dart(),
+                field0.into_into_dart().into_dart(),
+                field1.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::structs::ApiSetupWalletType
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::structs::ApiSetupWalletType>
+    for crate::api::structs::ApiSetupWalletType
+{
+    fn into_into_dart(self) -> crate::api::structs::ApiSetupWalletType {
         self
     }
 }
@@ -1678,6 +1766,51 @@ impl SseEncode for crate::api::structs::Amount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.0, serializer);
+    }
+}
+
+impl SseEncode for crate::api::structs::ApiSetupResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_blob, serializer);
+        <Option<String>>::sse_encode(self.mnemonic, serializer);
+    }
+}
+
+impl SseEncode for crate::api::structs::ApiSetupWalletArgs {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::structs::ApiSetupWalletType>::sse_encode(self.setup_type, serializer);
+        <u32>::sse_encode(self.birthday, serializer);
+        <String>::sse_encode(self.network, serializer);
+    }
+}
+
+impl SseEncode for crate::api::structs::ApiSetupWalletType {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::structs::ApiSetupWalletType::NewWallet => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::structs::ApiSetupWalletType::Mnemonic(field0) => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::api::structs::ApiSetupWalletType::Full(field0, field1) => {
+                <i32>::sse_encode(2, serializer);
+                <String>::sse_encode(field0, serializer);
+                <String>::sse_encode(field1, serializer);
+            }
+            crate::api::structs::ApiSetupWalletType::WatchOnly(field0, field1) => {
+                <i32>::sse_encode(3, serializer);
+                <String>::sse_encode(field0, serializer);
+                <String>::sse_encode(field1, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 

--- a/rust/src/wallet/wallet.rs
+++ b/rust/src/wallet/wallet.rs
@@ -21,15 +21,10 @@ pub struct SpWallet {
     pub birthday: Height,
     pub last_scan: Height,
     pub outputs: HashMap<OutPoint, OwnedOutput>,
-    pub mnemonic: Option<String>,
 }
 
 impl SpWallet {
-    pub fn new(
-        client: SpClient,
-        birthday: u32,
-        mnemonic: Option<String>,
-    ) -> Result<Self> {
+    pub fn new(client: SpClient, birthday: u32) -> Result<Self> {
         let wallet_fingerprint = client.get_client_fingerprint()?;
         let birthday = Height::from_consensus(birthday)?;
         let last_scan = birthday;
@@ -43,7 +38,6 @@ impl SpWallet {
             last_scan,
             tx_history,
             outputs,
-            mnemonic,
         })
     }
 

--- a/rust/src/wallet/wallet.rs
+++ b/rust/src/wallet/wallet.rs
@@ -22,7 +22,6 @@ pub struct SpWallet {
     pub last_scan: Height,
     pub outputs: HashMap<OutPoint, OwnedOutput>,
     pub mnemonic: Option<String>,
-    pub label: String,
 }
 
 impl SpWallet {
@@ -30,7 +29,6 @@ impl SpWallet {
         client: SpClient,
         birthday: u32,
         mnemonic: Option<String>,
-        label: String,
     ) -> Result<Self> {
         let wallet_fingerprint = client.get_client_fingerprint()?;
         let birthday = Height::from_consensus(birthday)?;
@@ -46,7 +44,6 @@ impl SpWallet {
             tx_history,
             outputs,
             mnemonic,
-            label,
         })
     }
 


### PR DESCRIPTION
- Move mnemonic out of SpWallet struct and save it separately.
- Add 'WalletRepository' class which is responsible for storing wallet data. 
- Remove wallet label from SpWallet
- Refactor setup wallet function to use a setup_type enum