### PR TITLE
Refactor scan progress from wallet state to scan notifier

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:danawallet/screens/create/create_wallet.dart';
 import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/home_state.dart';
+import 'package:danawallet/states/scan_progress_notifier.dart';
 import 'package:danawallet/states/spend_state.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/states/theme_notifier.dart';
@@ -15,8 +16,11 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await RustLib.init();
   final walletState = WalletState();
+  final scanNotifier = ScanProgressNotifier();
   final chainState = ChainState();
   final themeNotifier = ThemeNotifier();
+
+  await scanNotifier.initialize();
 
   final bool walletLoaded;
   try {
@@ -35,6 +39,7 @@ void main() async {
     MultiProvider(
       providers: [
         ChangeNotifierProvider.value(value: walletState),
+        ChangeNotifierProvider.value(value: scanNotifier),
         ChangeNotifierProvider.value(value: themeNotifier),
         ChangeNotifierProvider.value(value: chainState),
         ChangeNotifierProvider.value(value: SpendState()),

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:danawallet/generated/rust/api/stream.dart';
+import 'package:flutter/material.dart';
+
+class ScanProgressNotifier extends ChangeNotifier {
+  bool scanning = false;
+  double progress = 0.0;
+  int current = 0;
+
+  late StreamSubscription scanProgressSubscription;
+
+  ScanProgressNotifier();
+
+  Future<void> initialize() async {
+    scanProgressSubscription = createScanProgressStream().listen(((event) {
+      int start = event.start;
+      current = event.current;
+      int end = event.end;
+      double scanned = (current - start).toDouble();
+      double total = (end - start).toDouble();
+      double progress = scanned / total;
+      if (current == end) {
+        progress = 0.0;
+        scanning = false;
+      }
+      this.progress = progress;
+
+      notifyListeners();
+    }));
+  }
+
+  @override
+  void dispose() {
+    scanProgressSubscription.cancel();
+    super.dispose();
+  }
+
+  void activate(int start) {
+    scanning = true;
+    progress = 0.0;
+    current = start;
+    notifyListeners();
+  }
+
+  void deactivate() {
+    scanning = false;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
Add scan progress notifier for handling scan progress, instead of having all progress managed by the wallet state.