### PR TITLE
Bug fix: Serialize network name in core arg format

### DIFF
--- a/rust/src/api/structs.rs
+++ b/rust/src/api/structs.rs
@@ -303,7 +303,7 @@ impl From<SilentPaymentUnsignedTransaction> for ApiSilentPaymentUnsignedTransact
             unsigned_tx: value
                 .unsigned_tx
                 .map(|tx| serialize(&tx).to_lower_hex_string()),
-            network: value.network.to_string(),
+            network: value.network.to_core_arg().to_string(),
         }
     }
 }


### PR DESCRIPTION
Before, the network would be a toString of the network enum name, so that would be 'bitcoin', 'testnet', 'signet'. Instead it should be 'main', 'test' and 'signet'.

I didn't notice this since I always use signet to test things, and that one's the same.