### PR TITLE
Un-hide configure blindbit server option

### DIFF
--- a/lib/screens/home/settings/settings.dart
+++ b/lib/screens/home/settings/settings.dart
@@ -166,13 +166,12 @@ class SettingsScreen extends StatelessWidget {
             BitcoinButtonOutlined(
                 title: 'Set scan height',
                 onPressed: () => _setLastScan(context, walletState, homeState)),
-          if (isDevEnv)
-            BitcoinButtonOutlined(
-              title: 'Set backend url',
-              onPressed: () {
-                _setBlindbitUrl(context, walletState.network);
-              },
-            ),
+          BitcoinButtonOutlined(
+            title: 'Set backend url',
+            onPressed: () {
+              _setBlindbitUrl(context, walletState.network);
+            },
+          ),
           if (isDevEnv)
             BitcoinButtonOutlined(
               title: 'Set dust threshold',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: danawallet
 description: A silent payments wallet built in flutter.
 publish_to: 'none'
-version: 0.5.2+10
+version: 0.5.3+12
 
 environment:
   sdk: ^3.5.2


### PR DESCRIPTION
Since we now do some (basic) validation on the blindbit server, we can let users configure this option.