### PR TITLE
build: do no error on just clean-bin over a fresh repo

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -1,7 +1,7 @@
 default: clean-bin build-emulator build-android
 
 clean-bin:
-    rm -r ../android/app/src/main/jniLibs/*
+    rm -fRd ../android/app/src/main/jniLibs/*
 
 gen:
     flutter_rust_bridge_codegen generate --config-file ../flutter_rust_bridge.yaml --enable-lifetime


### PR DESCRIPTION
`just clean-bin` is failing on a fresh repo:

```shell
~/da/danawallet/rust master *1 !1 ❯ just clean-bin
rm -r ../android/app/src/main/jniLibs/*
rm: cannot remove '../android/app/src/main/jniLibs/*': No such file or directory
error: Recipe `clean-bin` failed on line 4 with exit code 1
```