### PR TITLE
Block user from going back on intro screen

### DIFF
--- a/lib/screens/onboarding/introduction.dart
+++ b/lib/screens/onboarding/introduction.dart
@@ -41,9 +41,11 @@ class IntroductionScreen extends StatelessWidget {
         onPressed: () => Navigator.push(context,
             MaterialPageRoute(builder: (context) => const OverviewScreen())));
 
-    return OnboardingSkeleton(
-      body: body,
-      footer: footer,
-    );
+    return PopScope(
+        canPop: false,
+        child: OnboardingSkeleton(
+          body: body,
+          footer: footer,
+        ));
   }
 }


### PR DESCRIPTION
Same issue as home screen: if the user presses back then the frb channels get messed up. So block users from pressing back on this screen.